### PR TITLE
fixing no tract error, scrolling function and a minor css edit

### DIFF
--- a/src/components/AddressDataTables/CensusTable.jsx
+++ b/src/components/AddressDataTables/CensusTable.jsx
@@ -63,14 +63,16 @@ export const CensusTable = (props) => {
 		const promises = []
 
 		decennials.forEach(d => {
-			let thisYearsTract = lookups[0][`tract_${d}`];
-			let queryURL = `https://api.baserow.io/api/database/rows/table/25442/?user_field_names=true&filter__field_133865__equal=${thisYearsTract}&filter__field_133866__equal=${d}`
-			
-			promises.push(getTractData(queryURL, d))
+			if(lookups.length >= 1){
+				let thisYearsTract = lookups[0][`tract_${d}`];
+				let queryURL = `https://api.baserow.io/api/database/rows/table/25442/?user_field_names=true&filter__field_133865__equal=${thisYearsTract}&filter__field_133866__equal=${d}`
+				
+				promises.push(getTractData(queryURL, d))
+			}
 		})
 
 		await Promise.all(promises)
-		console.log('[loadCensus] done, tempData: ', tempData)
+		//console.log('[loadCensus] done, tempData: ', tempData)
 		setAllCensusData(tempData)
 	}
 
@@ -99,8 +101,7 @@ export const CensusTable = (props) => {
 		if(allCensusData){ allCensusData.sort((a, b) => (a.year > b.year) ? 1 : -1) }  
 		return (
 			<>
-				{ 
-					allCensusData ? 
+				{ allCensusData ? 
 					allCensusData.map((year, keytwo) => {
 						if (ent.shortname === 'tract') {
 							return (
@@ -151,7 +152,7 @@ export const CensusTable = (props) => {
 			className={"censusTable dataTable " + (isVisible ? "active" : "inactive")}
 		>
 			<h1>Census</h1> 
-			<span className="see-notes">See Notes ></span>
+			{/*<span className="see-notes">See Notes ></span>*/}
 			<span>{ renderRows() }</span>
 		</div>
 	)

--- a/src/components/NavAddress.jsx
+++ b/src/components/NavAddress.jsx
@@ -27,14 +27,19 @@ export const NavAddress = (props) => {
 
 
   // ---------------------------------------------------------------
-    // window.onscroll = (e) =>{
-    //     let st = window.pageYOffset
-    //     if (st > 419){
-    //      navRef.current.classList.add('stuck')
-    //    }else{
-    //     navRef.current.classList.remove('stuck')
-    //    }
-    // }
+  useEffect( () => {
+    window.onscroll = (e) =>{
+        let st = window.pageYOffset
+        if (st > 419 && navRef.current){
+         navRef.current.classList.add('stuck')
+       }else if(st < 419 && navRef.current){
+        navRef.current.classList.remove('stuck')
+       }
+    }
+    return function cleanup(){
+      window.onscroll = (e) =>{}
+    }
+  }, [] )
 
   // ---------------------------------------------------------------
   const loadNextAddess = (url) => {

--- a/src/styles/AddressView.scss
+++ b/src/styles/AddressView.scss
@@ -4,7 +4,6 @@
 
 	.nav-header h1{
 	font-size: 16px;
-    margin-left: 28px;
     font-weight: 500;
 	}
 


### PR DESCRIPTION
census table returned an error if there was no tract data for an address, just checkes to make sure it exists before rendering table.
fixed scrolling function on address page by checking for ref and killing sitching out the scroll function for an empty one when component dismounts.
also the site title on address page had a weird margin that I missed.